### PR TITLE
Add dark mode toggle

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { Switch, Route } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { ThemeProvider } from "next-themes";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/hooks/use-auth";
@@ -28,14 +29,16 @@ function Router() {
 
 function App() {
   return (
-    <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
-        <AuthProvider>
-          <Toaster />
-          <Router />
-        </AuthProvider>
-      </TooltipProvider>
-    </QueryClientProvider>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <QueryClientProvider client={queryClient}>
+        <TooltipProvider>
+          <AuthProvider>
+            <Toaster />
+            <Router />
+          </AuthProvider>
+        </TooltipProvider>
+      </QueryClientProvider>
+    </ThemeProvider>
   );
 }
 

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -3,6 +3,7 @@ import { Button } from "@/components/ui/button";
 import { useLocation } from "wouter";
 import { useAuth } from "@/hooks/use-auth";
 import { RefreshCw, Dumbbell } from "lucide-react";
+import { ThemeToggle } from "./theme-toggle";
 
 export function Header() {
   const [location, setLocation] = useLocation();
@@ -27,7 +28,7 @@ export function Header() {
           </div>
           <div className="flex items-center space-x-4">
             {user?.isAdmin && (
-              <Button 
+              <Button
                 onClick={toggleView}
                 className="bg-primary hover:bg-primary/90 text-white"
               >
@@ -35,6 +36,7 @@ export function Header() {
                 {isAdminView ? "Vista Cliente" : "Vista Admin"}
               </Button>
             )}
+            <ThemeToggle />
             <div className="flex items-center space-x-2">
               <img
                 src={user?.profileImage || "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop&crop=face"}

--- a/client/src/components/layout/theme-toggle.tsx
+++ b/client/src/components/layout/theme-toggle.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Button } from "@/components/ui/button";
+import { Moon, Sun } from "lucide-react";
+
+export function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+      aria-label="Toggle theme"
+    >
+      {isDark ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `ThemeToggle` component using `next-themes`
- include the toggle button in the header
- wrap the app with `ThemeProvider`

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6846f6bbd0708322bce3d99284fcdc75